### PR TITLE
Correcting calculation of confidence interval

### DIFF
--- a/seaborn_qqplot/transforms.py
+++ b/seaborn_qqplot/transforms.py
@@ -70,8 +70,8 @@ class ConfidenceInterval(TransformMixin):
         _, y2   = regression(x2, y)
         df      = N - 2
         q_t     = t.ppf(self.p, df)
-        s_err   = np.sqrt(np.sum((self.y - y1)**2)/(df))
-        c       = q_t * s_err * np.sqrt(1/N + (x2-np.mean(self.x))**2/np.sum((self.x-np.mean(self.x))**2))
+        s_err   = self.y.std(ddof=2)
+        c       = q_t * s_err * np.sqrt(1/N) + (x2-np.mean(self.x))**2/np.sum((self.x-np.mean(self.x))**2
         return x2, y2+c, y2-c
 
 class Scale(TransformMixin):


### PR DESCRIPTION
Hello @RonsenbergVI , I was trying to use your library to plot some confidence intervals and I wasn't getting satisfying results.
I don't have any way to check the formulas, but to use my rusty statistics knowledge. 
However, I think the standard deviation is wrongly calculated and the mean estimator term @74 should not go under the square root.
As far as I know T ~ (x - mean)/(s/sqrt(N)), hence inverting: t*s/sqrt(n) + mean.
With these changes, I get some better results on a dataset of mine. Let me know if you agree!

In summary:
- Correcting std dev calculation using numpy;
- Correcting Student T formula using T ~ (x - mean)/(s/sqrt(N)) --> t*s/sqrt(n) + mean.